### PR TITLE
Reduce WS communication

### DIFF
--- a/src/client/main.js
+++ b/src/client/main.js
@@ -4,16 +4,7 @@ import { render } from 'react-dom';
 import React from 'react';
 
 import store from './store';
-import renderPlayground from './render';
-
 import key from './lib/keypress';
-
-const tick = () => {
-  if (!store.getState().game) return requestAnimationFrame(tick);
-  renderPlayground(store);
-  requestAnimationFrame(tick);
-};
-tick();
 
 function accelerate(index, strength) {
   store.dispatch({

--- a/src/client/render.js
+++ b/src/client/render.js
@@ -1,50 +1,68 @@
-let ctx;
+import simulate from '../common/game';
 
-export default function render(store) {
-  const state = store.getState();
-  if (!ctx) {
-    ctx = document.getElementById('canvas').getContext('2d');
-  }
-  ctx.save();
-  ctx.clearRect(0, 0, 500, 500);
-  ctx.translate(250.5, 250.5);
-  ctx.scale(1, -1);
+export default function render(offset, store) {
+  const ctx = document.getElementById('canvas').getContext('2d');
+  console.log('Game started at %s', new Date(offset));
 
-  // for each ship
-  for (const ship of state.game.ships) {
-    // draw hull
+  function render() {
+    let state = store.getState().game;
+    if (!state) return;
+
+    state = simulate(state, {
+      type: 'NOOP',
+      payload: {
+        time: Date.now() - offset,
+      },
+    });
+
     ctx.save();
-    ctx.translate(ship.position.x, ship.position.y);
-    ctx.rotate(ship.orientation);
-    ctx.fillRect(-5, -10, 10, 20);
-    ctx.beginPath();
-    ctx.moveTo(-5, -10);
-    ctx.lineTo(-5, 10);
-    ctx.lineTo(0, 15);
-    ctx.lineTo(5, 10);
-    ctx.lineTo(5, -10);
-    ctx.fill();
-    for (const thruster of ship.thrusters) {
-      if (thruster.strength === 0) {
-        continue;
-      }
+    ctx.clearRect(0, 0, 500, 500);
+    ctx.translate(250.5, 250.5);
+    ctx.scale(1, -1);
+
+    // for each ship
+    for (const ship of state.ships) {
+      // draw hull
       ctx.save();
-      ctx.fillStyle = 'red';
-      ctx.translate(thruster.position.x, thruster.position.y);
-      ctx.rotate(thruster.orientation);
-      ctx.fillRect(-2, 0, 4, Math.log(10000 * thruster.strength) * -2);
+      ctx.translate(ship.position.x, ship.position.y);
+      ctx.rotate(ship.orientation);
+      ctx.fillRect(-5, -10, 10, 20);
+      ctx.beginPath();
+      ctx.moveTo(-5, -10);
+      ctx.lineTo(-5, 10);
+      ctx.lineTo(0, 15);
+      ctx.lineTo(5, 10);
+      ctx.lineTo(5, -10);
+      ctx.fill();
+      for (const thruster of ship.thrusters) {
+        if (thruster.strength === 0) {
+          continue;
+        }
+        ctx.save();
+        ctx.fillStyle = 'red';
+        ctx.translate(thruster.position.x, thruster.position.y);
+        ctx.rotate(thruster.orientation);
+        ctx.fillRect(-2, 0, 4, Math.log(10000 * thruster.strength) * -2);
+        ctx.restore();
+      }
+      ctx.restore();
+    }
+
+    for (const projectile of state.projectiles) {
+      ctx.save();
+      ctx.translate(projectile.position.x, projectile.position.y);
+      ctx.rotate(projectile.orientation);
+      ctx.fillStyle = 'green';
+      ctx.fillRect(-2.5, -10, 5, 20);
       ctx.restore();
     }
     ctx.restore();
   }
 
-  for (const projectile of state.game.projectiles) {
-    ctx.save();
-    ctx.translate(projectile.position.x, projectile.position.y);
-    ctx.rotate(projectile.orientation);
-    ctx.fillStyle = 'green';
-    ctx.fillRect(-2.5, -10, 5, 20);
-    ctx.restore();
+  function tick() {
+    render();
+    requestAnimationFrame(tick);
   }
-  ctx.restore();
+
+  tick();
 }

--- a/src/client/store.js
+++ b/src/client/store.js
@@ -5,6 +5,7 @@ import route from './reducers/navigation';
 import game from '../common/game';
 
 import websocket from './middlewares/websocket';
+import initRender from './render';
 
 const middlewares = [
   store => next => action => {
@@ -13,12 +14,19 @@ const middlewares = [
       next(action);
       store.dispatch({
         type: 'INIT_GAME',
+        meta: {
+          pending: true,
+        }
       });
       return;
     }
     next(action);
   },
   websocket,
+  store => next => action => {
+    if (action.type === 'INIT_GAME') initRender(Date.now() - action.payload.time, store);
+    return next(action);
+  }
 ];
 
 const store = applyMiddleware(...middlewares)(createStore)(combineReducers({

--- a/src/server/services/client.js
+++ b/src/server/services/client.js
@@ -62,6 +62,7 @@ class Client {
         }
       });
     });
+    this.dispatch('INIT_GAME', game.state);
     this.socket.on('close', unsubscribe);
   }
 }

--- a/test/game.test.js
+++ b/test/game.test.js
@@ -3,6 +3,8 @@ import game from '../src/common/game';
 
 test('stationary ship stays stationary', t => {
   const initial = {
+    time: 0,
+    step: 1,
     ships: [{
       position: { x: 0, y: 0 },
       velocity: { x: 0, y: 0 },
@@ -14,6 +16,9 @@ test('stationary ship stays stationary', t => {
   };
   let next = game(initial, {
     type: 'TICK',
+    payload: {
+      time: 1,
+    },
   }).ships;
 
   t.same(next[0].position, { x: 0, y: 0 });
@@ -26,6 +31,8 @@ test('stationary ship stays stationary', t => {
 
 test('moving ship does not lose energy', t => {
   const initial = {
+    time: 0,
+    step: 1,
     ships: [{
       position: { x: 0, y: 0 },
       velocity: { x: 1, y: 1 },
@@ -37,6 +44,9 @@ test('moving ship does not lose energy', t => {
   };
   let next = game(initial, {
     type: 'TICK',
+    payload: {
+      time: 1,
+    },
   }).ships;
 
   t.same(next[0].position, { x: 1, y: 1 });


### PR DESCRIPTION
Tick events were removed, so WS communication happens only when it's _really_ necessery (some user input happened). Tick events were basically synchronization points, without this, the clients have no information about the current server state, so they simulate elapsed time (for rendering the current state), assuming that nothing happened on the server. 
