### PR TITLE
Use path instead of url

### DIFF
--- a/src/server/routes/main.js
+++ b/src/server/routes/main.js
@@ -26,7 +26,7 @@ const spa =
 <script src=bundle.js></script>${analytics}`;
 
 export default function* (next) {
-  switch (this.url) {
+  switch (this.path) {
     case '/':
     case '/login':
     case '/lobby':


### PR DESCRIPTION
url contains the query string, so one cannot pass parameters to the site right now
